### PR TITLE
Adjust the dark theme as Vim solarized dark

### DIFF
--- a/solarized-dark.xml
+++ b/solarized-dark.xml
@@ -7,6 +7,7 @@
   <style name="SearchResult" background="#555000"/>
   <style name="SearchScope" background="#222000"/>
   <style name="Parentheses" foreground="#dc322f"/>
+  <style name="ParenthesesMismatch" foreground="#000000" background="#ff00ff"/>
   <style name="CurrentLine" background="#073642"/>
   <style name="CurrentLineNumber" foreground="#586e75" bold="true"/>
   <style name="Occurrences" background="#586e75"/>
@@ -14,19 +15,20 @@
   <style name="Occurrences.Rename" foreground="#000000" background="#ff6464"/>
   <style name="Number" foreground="#2aa198"/>
   <style name="String" foreground="#2aa198"/>
-  <style name="Type" foreground="#839496"/>
+  <style name="Type" foreground="#b58900"/>
   <style name="Local" foreground="#839496"/>
   <style name="Field" foreground="#839496"/>
   <style name="Static" foreground="#859900" italic="true"/>
-  <style name="VirtualMethod" italic="true"/>
-  <style name="Function" foreground="#586e75"/>
-  <style name="Keyword" foreground="#c4a000" bold="true"/>
-  <style name="Operator" foreground="#586e75"/>
-  <style name="Preprocessor" foreground="#6c71c4"/>
+  <style name="VirtualMethod" foreground="#268bd2" italic="true"/>
+  <style name="Function" foreground="#268bd2"/>
+  <style name="Keyword" foreground="#859900"/>
+  <style name="PrimitiveType" foreground="#808000"/>
+  <style name="Operator" foreground="#839496"/>
+  <style name="Preprocessor" foreground="#cb4b16"/>
   <style name="Label" foreground="#586e75" bold="true"/>
   <style name="Comment" foreground="#586e75"/>
-  <style name="Doxygen.Comment" foreground="#93a1a1"/>
-  <style name="Doxygen.Tag" foreground="#2aa198"/>
+  <style name="Doxygen.Comment" foreground="#586e75"/>
+  <style name="Doxygen.Tag" foreground="#586e75"/>
   <style name="VisualWhitespace" foreground="#c0c0c0"/>
   <style name="QmlLocalId" foreground="#586e75" italic="true"/>
   <style name="QmlExternalId" foreground="#3465a4" italic="true"/>
@@ -39,7 +41,7 @@
   <style name="JsGlobalVar" foreground="#0055af" italic="true"/>
   <style name="QmlStateName" foreground="#586e75" italic="true"/>
   <style name="Binding" foreground="#586e75"/>
-  <style name="DisabledCode" foreground="#93a1a1"/>
+  <style name="DisabledCode" foreground="#586e75"/>
   <style name="AddedLine" foreground="#2aa198"/>
   <style name="RemovedLine" foreground="#dc322f"/>
   <style name="DiffFile" foreground="#859900"/>
@@ -50,4 +52,5 @@
   <style name="DiffSourceChar" background="#ffafaf"/>
   <style name="DiffDestLine" background="#dfffdf"/>
   <style name="DiffDestChar" background="#afffaf"/>
+  <style name="LogChangeLine" foreground="#c00000"/>
 </style-scheme>


### PR DESCRIPTION
The adjustments are taken from the vim plugin:
https://github.com/altercation/vim-colors-solarized

The scheme is only tested for C++.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/artm/qtcreator-solarized-syntax/6)

<!-- Reviewable:end -->
